### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/adelra/fastbu/security/code-scanning/3](https://github.com/adelra/fastbu/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, it primarily reads repository contents and does not perform write operations. Therefore, the `contents: read` permission is sufficient.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build` job. In this case, adding it at the root level is recommended for simplicity and consistency.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
